### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if sys.version_info < (3, 6):
 __version__ = ""
 exec(open('efb_qq_slave/__version__.py').read())
 
-long_description = open('README.rst').read()
+long_description = open('README.rst', encoding='utf-8').read()
 
 setup(
     name='efb-qq-slave',


### PR DESCRIPTION
Use utf-8 encoding to avoid the encoding error:

        long_description = open('README.rst').read()
    UnicodeDecodeError: 'gbk' codec can't decode byte 0xab in position 108: illegal multibyte sequence